### PR TITLE
Add bundle publishing

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,3 +23,8 @@ jobs:
         with:
           credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
           charm-path: test-charm/
+
+      - uses: ./
+        with:
+          credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+          bundle-path: test-bundle/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # charmhub-upload
 
-This action allows you to easily upload a charmed operator to [charmhub.io][charmhub].
+This action allows you to easily upload a charmed operator or bundle of charmed operators to
+[charmhub.io][charmhub].
 
 [charmhub]: https://charmhub.io/
 
 
 ## Usage
+
+### Workflow
 
 To use this action, start by adding a repository secret to your Github repository. In the example
 below, it's called `CHARMCRAFT_AUTH`, but can be anything you want. Then, add a step like this to
@@ -21,8 +24,51 @@ your Github Workflow:
 
 [auth]: https://juju.is/docs/sdk/remote-env-auth
 
+If you're uploading a single charm that exists in the current directory, that's all you need.
+
+If you've got a charm at a different path, you can upload the charm like this:
+
+
+```yaml
+- uses: canonical/charmhub-upload-action@0.1.0
+  with:
+    credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+    charm-path: my-charm/
+```
+
+If you'd like to upload a bundle instead of a charm, you can do so like this:
+
+
+```yaml
+- uses: canonical/charmhub-upload-action@0.1.0
+  with:
+    credentials: "${{ secrets.CHARMCRAFT_AUTH }}"
+    bundle-path: my-bundle/
+```
+
+### Branch Selection
+
+This action automatically selects a Charmhub channel based on the Github branch naming. For `push`
+events, a Charmhub channel is selected. For `pull_request` events, a Charmhub branch is selected, so
+that the PR can be tested.
+
+The Charmhub channel/branch selection logic looks like this:
+
+| Event Type   | Head                   | Base/Branch          | Channel                           |
+|:------------:|:----------------------:|:--------------------:|:---------------------------------:|
+| push         |                        | `<default branch>`   | `latest/edge`                     |
+| push         |                        | `track/<track-name>` | `<track-name>/edge`               |
+| push         |                        | Any other name       | Ignored                           |
+| pull_request | `branch/<branch-name>` | `<default branch>`   | `latest/edge/<branch-name>`       |
+| pull_request | `branch/<branch-name>` | `track/<track-name>` | `<track-name>/edge/<branch-name>` |
+| pull_request | Any other name         | Any other name       | Ignored                           |
+
+### Available Inputs
+
 The list of available inputs for this action are:
 
+ - `bundle-path`
+   - Path to the bundle to be uploaded. Optional; If set, `charm-path` will be ignored.
  - `charm-path`
    - Path to the charm to be uploaded. Optional, defaults to `'.'`.
  - `charmcraft-channel`

--- a/action.yaml
+++ b/action.yaml
@@ -2,11 +2,9 @@ name: Charmhub Upload
 description: Uploads a charm to charmhub.io
 author: Kenneth Koski
 inputs:
-  credentials:
-    description: |
-      Credentials exported from `charmcraft login --export`. See
-      https://juju.is/docs/sdk/remote-env-auth for more info
-    required: true
+  bundle-path:
+    description: Path to bundle.yaml
+    required: false
   charm-path:
     description: Path to charm directory
     required: false
@@ -15,6 +13,11 @@ inputs:
     description: Snap channel to use when installing charmcraft
     required: false
     default: "latest/edge"
+  credentials:
+    description: |
+      Credentials exported from `charmcraft login --export`. See
+      https://juju.is/docs/sdk/remote-env-auth for more info
+    required: true
 runs:
   using: node12
   main: dist/index.js

--- a/main.js
+++ b/main.js
@@ -6,13 +6,14 @@ const exec = require('@actions/exec');
 const fs = require('fs');
 const github = require('@actions/github');
 const glob = require('@actions/glob');
+const process = require('process');
 const yaml = require('js-yaml');
-import { chdir } from 'process';
 
 (async () => {
   try {
     const credentials = core.getInput('credentials');
     const charm_path = core.getInput('charm-path');
+    const bundle_path = core.getInput('bundle-path');
     const charmcraft_channel = core.getInput('charmcraft-channel');
 
     await exec.exec('sudo', [
@@ -24,15 +25,16 @@ import { chdir } from 'process';
       charmcraft_channel,
     ]);
 
-    chdir(charm_path);
+    if (bundle_path) {
+      await exec.exec('sudo', [
+        'snap',
+        'install',
+        'juju-bundle',
+        '--classic',
+      ]);
+    }
+
     core.exportVariable('CHARMCRAFT_AUTH', credentials);
-
-    const metadata = yaml.load(fs.readFileSync('metadata.yaml'));
-
-    const name = metadata.name;
-    const images = Object.entries(metadata.resources || {})
-      .filter(([_, res]) => res.type === 'oci-image')
-      .map(([name, res]) => [name, res['upstream-source']]);
 
     const ctx = github.context;
     const event = ctx.eventName;
@@ -80,36 +82,52 @@ import { chdir } from 'process';
       return;
     }
 
-    await exec.exec('charmcraft', ['pack', '--destructive-mode', '--quiet']);
 
-    const revisions = await Promise.all(
-      images.map(async ([resource_name, resource_image]) => {
-        await exec.exec('docker', ['pull', resource_image]);
-        await exec.exec('charmcraft', [
-          'upload-resource',
-          '--quiet',
-          name,
-          resource_name,
-          '--image',
-          resource_image,
-        ]);
-        let result = await exec.getExecOutput('charmcraft', ['resource-revisions', name, resource_name]);
-        let revision = result.stdout.split('\n')[1].split(' ')[0];
+    // Publish a bundle or a charm, depending on if `bundle_path` or `charm_path` was set
+    if (bundle_path) {
+      process.chdir(bundle_path);
+      await exec.exec('juju-bundle', ['publish', '--destructive-mode', '--serial', '--release', channel]);
+    } else {
+      process.chdir(charm_path);
+      const metadata = yaml.load(fs.readFileSync('metadata.yaml'));
 
-        return `--resource=${resource_name}:${revision}`;
-      })
-    );
+      const name = metadata.name;
+      const images = Object.entries(metadata.resources || {})
+        .filter(([_, res]) => res.type === 'oci-image')
+        .map(([name, res]) => [name, res['upstream-source']]);
 
-    const globber = await glob.create('./*.charm');
-    const paths = await globber.glob();
+      await exec.exec('charmcraft', ['pack', '--destructive-mode', '--quiet']);
 
-    await Promise.all(
-      paths.map((path) =>
-        exec.exec('charmcraft', ['upload', '--quiet', '--release', channel, path].concat(revisions))
-      )
-    );
+      const revisions = await Promise.all(
+        images.map(async ([resource_name, resource_image]) => {
+          await exec.exec('docker', ['pull', resource_image]);
+          await exec.exec('charmcraft', [
+            'upload-resource',
+            '--quiet',
+            name,
+            resource_name,
+            '--image',
+            resource_image,
+          ]);
+          let result = await exec.getExecOutput('charmcraft', ['resource-revisions', name, resource_name]);
+          let revision = result.stdout.split('\n')[1].split(' ')[0];
+
+          return `--resource=${resource_name}:${revision}`;
+        })
+      );
+
+      const globber = await glob.create('./*.charm');
+      const paths = await globber.glob();
+
+      await Promise.all(
+        paths.map((path) =>
+          exec.exec('charmcraft', ['upload', '--quiet', '--release', channel, path].concat(revisions))
+        )
+      );
+    }
   } catch (error) {
     core.setFailed(error.message);
+    core.error(error.stack);
   } finally {
     const root = '/home/runner/snap/charmcraft/common/cache/charmcraft/log/';
 

--- a/test-bundle/README.md
+++ b/test-bundle/README.md
@@ -1,0 +1,1 @@
+# Charmhub Upload Bundle Test

--- a/test-bundle/bundle.yaml
+++ b/test-bundle/bundle.yaml
@@ -1,0 +1,7 @@
+name: charmhub-upload-test-bundle
+bundle: kubernetes
+applications:
+  charmhub-upload-test:
+    charm: charmhub-upload-test
+    source: ../test-charm
+    scale: 1

--- a/test-bundle/charmcraft.yaml
+++ b/test-bundle/charmcraft.yaml
@@ -1,0 +1,1 @@
+type: bundle

--- a/test-charm/metadata.yaml
+++ b/test-charm/metadata.yaml
@@ -1,5 +1,4 @@
 name: charmhub-upload-test
-display-name: Charmhub Upload Test
 summary: Charm for testing charmhub-upload-action
 description: Charm for testing charmhub-upload-action
 containers:


### PR DESCRIPTION
Allows for publishing a bundle as well as a charm. Presents `bundle-path` option that can be set instead of `charm-path`.